### PR TITLE
Update typed-ast to 1.4.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,6 @@ regex==2020.7.14
 requests==2.24.0
 six==1.15.0
 toml==0.10.1
-typed-ast==1.4.1
+typed-ast==1.4.3
 urllib3==1.25.9
 wrapt==1.12.1


### PR DESCRIPTION
To fix compilation on Python 3.10 and newer, we need to bump typed-ast to 1.4.3 to get the fix from python/typed_ast#158.