### PR TITLE
Support parsing multiple files in an update request + endpoints for status/refresh + minor refactoring

### DIFF
--- a/pgesmd_self_access/helpers.py
+++ b/pgesmd_self_access/helpers.py
@@ -127,7 +127,7 @@ def save_espi_xml(self, xml_data, filename=None):
     if filename:
         save_name = f"{os.getcwd()}/data/espi_xml/{filename}.xml"
     else:
-        timestamp = time.strftime("%y.%m.%d %H:%M:%S", time.localtime())
+        timestamp = time.strftime("%Y%m%d_%H%M%S", time.localtime())
         save_name = f"{os.getcwd()}/data/espi_xml/{timestamp}.xml"
 
     with open(save_name, "w") as file:

--- a/pgesmd_self_access/helpers.py
+++ b/pgesmd_self_access/helpers.py
@@ -129,6 +129,11 @@ def save_espi_xml(self, xml_data, filename=None):
     else:
         timestamp = time.strftime("%Y%m%d_%H%M%S", time.localtime())
         save_name = f"{os.getcwd()}/data/espi_xml/{timestamp}.xml"
+    
+    # Create the directory if it doesn't exist
+    directory = os.path.dirname(save_name)
+    if not os.path.exists(directory):
+        os.makedirs(directory, exist_ok=True)
 
     with open(save_name, "w") as file:
         file.write(xml_data)

--- a/pgesmd_self_access/pgesmd.py
+++ b/pgesmd_self_access/pgesmd.py
@@ -4,6 +4,7 @@ import os
 import sys
 import logging
 import argparse
+import importlib
 
 from .api import SelfAccessApi
 from .server import SelfAccessServer
@@ -52,6 +53,7 @@ parser.add_argument("--client_secret", required=True)
 parser.add_argument("--certificate_path", required=True)
 parser.add_argument("--certificate_key_path", required=True)
 parser.add_argument("--server_port", type=int, required=True)
+parser.add_argument("--db_callback", help="Fully qualified name of function for writing parsed data to DB")
 args = parser.parse_args()
 
 if __name__ == "__main__":
@@ -65,7 +67,23 @@ if __name__ == "__main__":
     # Sanity check
     api.get_service_status()
 
+    # Dynamically load DB callback function
+    to_db = None
+    if args.db_callback:
+        parts = args.db_callback.split('.')
+        module_name = '.'.join(parts[:len(parts)-1])
+        func_name = parts[len(parts)-1]
+        module = importlib.import_module(module_name)
+        func = getattr(module, func_name)
+        if callable(func):
+            to_db = func
+
     try:
-        server = SelfAccessServer(api, args.server_port, save_file=save_espi_xml)
+        server = SelfAccessServer(
+            api,
+            args.server_port,
+            save_file=save_espi_xml,
+            to_db=to_db
+        )
     except KeyboardInterrupt:
         pass

--- a/pgesmd_self_access/pgesmd.py
+++ b/pgesmd_self_access/pgesmd.py
@@ -66,6 +66,6 @@ if __name__ == "__main__":
     api.get_service_status()
 
     try:
-        server = SelfAccessServer(api, args.server_port)
+        server = SelfAccessServer(api, args.server_port, save_file=save_espi_xml)
     except KeyboardInterrupt:
         pass

--- a/pgesmd_self_access/pgesmd.py
+++ b/pgesmd_self_access/pgesmd.py
@@ -46,12 +46,12 @@ def download_day_data(date):
         )
 
 parser = argparse.ArgumentParser()
-parser.add_argument("third_party_id")
-parser.add_argument("client_id")
-parser.add_argument("client_secret")
-parser.add_argument("certificate_path")
-parser.add_argument("certificate_key_path")
-parser.add_argument("server_port", type=int)
+parser.add_argument("--third_party_id", required=True)
+parser.add_argument("--client_id", required=True)
+parser.add_argument("--client_secret", required=True)
+parser.add_argument("--certificate_path", required=True)
+parser.add_argument("--certificate_key_path", required=True)
+parser.add_argument("--server_port", type=int, required=True)
 args = parser.parse_args()
 
 if __name__ == "__main__":
@@ -62,11 +62,8 @@ if __name__ == "__main__":
         args.certificate_path,
         args.certificate_key_path
     )
-
     # Sanity check
     api.get_service_status()
-
-    # request_post = api.request_latest_data()
 
     try:
         server = SelfAccessServer(api, args.server_port)

--- a/pgesmd_self_access/pgesmd.py
+++ b/pgesmd_self_access/pgesmd.py
@@ -3,8 +3,6 @@
 import os
 import sys
 import logging
-import argparse
-import importlib
 
 from .api import SelfAccessApi
 from .server import SelfAccessServer
@@ -46,44 +44,12 @@ def download_day_data(date):
             api, save_file=save_espi_xml, filename=date, to_db=False, close_after=True
         )
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--third_party_id", required=True)
-parser.add_argument("--client_id", required=True)
-parser.add_argument("--client_secret", required=True)
-parser.add_argument("--certificate_path", required=True)
-parser.add_argument("--certificate_key_path", required=True)
-parser.add_argument("--server_port", type=int, required=True)
-parser.add_argument("--db_callback", help="Fully qualified name of function for writing parsed data to DB")
-args = parser.parse_args()
 
 if __name__ == "__main__":
-    api = SelfAccessApi(
-        args.third_party_id,
-        args.client_id,
-        args.client_secret,
-        args.certificate_path,
-        args.certificate_key_path
-    )
-    # Sanity check
-    api.get_service_status()
-
-    # Dynamically load DB callback function
-    to_db = None
-    if args.db_callback:
-        parts = args.db_callback.split('.')
-        module_name = '.'.join(parts[:len(parts)-1])
-        func_name = parts[len(parts)-1]
-        module = importlib.import_module(module_name)
-        func = getattr(module, func_name)
-        if callable(func):
-            to_db = func
+    api = SelfAccessApi.auth()
+    request_post = api.request_latest_data()
 
     try:
-        server = SelfAccessServer(
-            api,
-            args.server_port,
-            save_file=save_espi_xml,
-            to_db=to_db
-        )
+        server = SelfAccessServer(api, save_file=save_espi_xml)
     except KeyboardInterrupt:
         pass

--- a/pgesmd_self_access/pgesmd.py
+++ b/pgesmd_self_access/pgesmd.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import logging
+import argparse
 
 from .api import SelfAccessApi
 from .server import SelfAccessServer
@@ -44,12 +45,30 @@ def download_day_data(date):
             api, save_file=save_espi_xml, filename=date, to_db=False, close_after=True
         )
 
+parser = argparse.ArgumentParser()
+parser.add_argument("third_party_id")
+parser.add_argument("client_id")
+parser.add_argument("client_secret")
+parser.add_argument("certificate_path")
+parser.add_argument("certificate_key_path")
+parser.add_argument("server_port", type=int)
+args = parser.parse_args()
 
 if __name__ == "__main__":
-    api = SelfAccessApi.auth()
-    request_post = api.request_latest_data()
+    api = SelfAccessApi(
+        args.third_party_id,
+        args.client_id,
+        args.client_secret,
+        args.certificate_path,
+        args.certificate_key_path
+    )
+
+    # Sanity check
+    api.get_service_status()
+
+    # request_post = api.request_latest_data()
 
     try:
-        server = SelfAccessServer(api, save_file=save_espi_xml)
+        server = SelfAccessServer(api, args.server_port)
     except KeyboardInterrupt:
         pass

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -27,6 +27,12 @@ class PgePostHandler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.end_headers()
             return
+        
+        if self.path == "/refresh":
+            self.api.request_latest_data()
+            self.send_response(200)
+            self.end_headers()
+            return
 
         body = self.rfile.read(int(self.headers.get("Content-Length")))
         _LOGGER.debug(body)

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -19,6 +19,17 @@ class PgePostHandler(BaseHTTPRequestHandler):
     filename = None
     to_db = None
     update_path = None
+
+    def do_GET(self):
+        _LOGGER.debug(f"Received GET from {self.address_string()}")
+
+        if self.path != "/status":
+            return
+
+        status = self.api.get_service_status()
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(str(status))
     
     def do_POST(self):
         """Download the ESPI XML and save to database."""

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -28,11 +28,6 @@ class PgePostHandler(BaseHTTPRequestHandler):
             self.end_headers()
             return
 
-        if not self.path == "/pgesmd":
-            return
-
-        _LOGGER.info(f"Received POST from {self.address_string()}")
-
         body = self.rfile.read(int(self.headers.get("Content-Length")))
         _LOGGER.debug(body)
         try:

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -80,8 +80,9 @@ class PgePostHandler(BaseHTTPRequestHandler):
                 else:
                     _LOGGER.error("File not saved.")
 
+            data = []
             try:
-                data = list(parse_espi_data(xml_data))
+                data.extend(parse_espi_data(xml_data))
                 for _ in data:
                     _LOGGER.debug(f"Parsed data: {_}")
             except Exception as e:

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -52,6 +52,10 @@ class PgePostHandler(BaseHTTPRequestHandler):
                     f"{resource_uri[:len(self.api.utility_uri)]}"
                     f" != {self.api.utility_uri}"
                 )
+                continue
+            if resource_uri.partition('correlationID=')[2] == '000000000-b':
+                _LOGGER.debug(f'Skipping {resource_uri}')
+                continue
             resource_uris.append(resource_uri)
         
         if len(resource_uris) == 0:

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -35,7 +35,7 @@ class PgePostHandler(BaseHTTPRequestHandler):
             self.end_headers()
             return
 
-        if not self.path == update_path:
+        if self.path != self.update_path:
             _LOGGER.debug(f"Unhandled path {self.path}")
             return
 

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -18,7 +18,8 @@ class PgePostHandler(BaseHTTPRequestHandler):
     save_file = None
     filename = None
     to_db = None
-
+    update_path = None
+    
     def do_POST(self):
         """Download the ESPI XML and save to database."""
         _LOGGER.debug(f"Received POST from {self.address_string()}")
@@ -32,6 +33,10 @@ class PgePostHandler(BaseHTTPRequestHandler):
             self.api.request_latest_data()
             self.send_response(200)
             self.end_headers()
+            return
+
+        if not self.path == update_path:
+            _LOGGER.debug(f"Unhandled path {self.path}")
             return
 
         body = self.rfile.read(int(self.headers.get("Content-Length")))
@@ -79,22 +84,33 @@ class PgePostHandler(BaseHTTPRequestHandler):
                 data = list(parse_espi_data(xml_data))
                 for _ in data:
                     _LOGGER.debug(f"Parsed data: {_}")
-                if self.to_db:
-                    self.to_db(data)
             except Exception as e:
                 _LOGGER.error(f"Failed to parse XML: {e}")
 
+            if self.to_db:
+                self.to_db(data)
+                _LOGGER.info(f"Wrote {len(data)} values to database")
+
+                
 class SelfAccessServer:
     """Server class for PGE SMD Self Access API."""
 
     def __init__(
-        self, api_instance, port=7999, save_file=None, filename=None, to_db=None, close_after=False
+        self,
+        api_instance,
+        port=7999,
+        save_file=None,
+        filename=None,
+        to_db=None,
+        close_after=False,
+        update_path="/pgesmd",
     ):
         """Initialize and start the server on construction."""
         PgePostHandler.api = api_instance
         PgePostHandler.save_file = save_file
         PgePostHandler.filename = filename
         PgePostHandler.to_db = to_db
+        PgePostHandler.update_path = update_path
         server = HTTPServer(("", port), PgePostHandler)
 
         if close_after:

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -70,21 +70,14 @@ class SelfAccessServer:
     """Server class for PGE SMD Self Access API."""
 
     def __init__(
-        self, api_instance, save_file=None, filename=None, to_db=True, close_after=False
+        self, api_instance, port=7999, save_file=None, filename=None, to_db=True, close_after=False
     ):
         """Initialize and start the server on construction."""
         PgePostHandler.api = api_instance
         PgePostHandler.save_file = save_file
         PgePostHandler.filename = filename
         PgePostHandler.to_db = to_db
-        server = HTTPServer(("", 7999), PgePostHandler)
-
-        server.socket = ssl.wrap_socket(
-            server.socket,
-            certfile=api_instance.cert[0],
-            keyfile=api_instance.cert[1],
-            server_side=True,
-        )
+        server = HTTPServer(("", port), PgePostHandler)
 
         if close_after:
             server.handle_request()

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -67,7 +67,8 @@ class PgePostHandler(BaseHTTPRequestHandler):
 
         for resource_uri in resource_uris:
             xml_data = self.api.get_espi_data(resource_uri)
-            for _ in parse_espi_data(xml_data):
+            data = parse_espi_data(xml_data)
+            for _ in data:
                 _LOGGER.debug(f"Parsed data: {_}")
 
             if self.save_file:
@@ -78,15 +79,14 @@ class PgePostHandler(BaseHTTPRequestHandler):
                     _LOGGER.error("File not saved.")
 
             if self.to_db:
-                _LOGGER.error("Database not implemented.")
-                pass
+                self.to_db(data)
 
 
 class SelfAccessServer:
     """Server class for PGE SMD Self Access API."""
 
     def __init__(
-        self, api_instance, port=7999, save_file=None, filename=None, to_db=True, close_after=False
+        self, api_instance, port=7999, save_file=None, filename=None, to_db=None, close_after=False
     ):
         """Initialize and start the server on construction."""
         PgePostHandler.api = api_instance

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -54,8 +54,8 @@ class PgePostHandler(BaseHTTPRequestHandler):
         _LOGGER.debug(body)
         try:
             batch_list = ET.fromstring(body)
-        except ET.ParseError:
-            _LOGGER.error(f"Could not parse message: {body}")
+        except ET.ParseError as e:
+            _LOGGER.error(f"Could not parse message: {body=} {e=}")
             return
         
         resource_uris = []
@@ -91,17 +91,8 @@ class PgePostHandler(BaseHTTPRequestHandler):
                 else:
                     _LOGGER.error("File not saved.")
 
-            data = []
-            try:
-                data.extend(parse_espi_data(xml_data))
-                for _ in data:
-                    _LOGGER.debug(f"Parsed data: {_}")
-            except Exception as e:
-                _LOGGER.error(f"Failed to parse XML: {e}")
-
             if self.to_db:
-                self.to_db(data)
-                _LOGGER.info(f"Wrote {len(data)} values to database")
+                self.to_db(xml_data)
 
                 
 class SelfAccessServer:

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -37,36 +37,44 @@ class PgePostHandler(BaseHTTPRequestHandler):
         body = self.rfile.read(int(self.headers.get("Content-Length")))
         _LOGGER.debug(body)
         try:
-            resource_uri = ET.fromstring(body)[0].text
+            batch_list = ET.fromstring(body)
         except ET.ParseError:
             _LOGGER.error(f"Could not parse message: {body}")
             return
-        if not resource_uri[: len(self.api.utility_uri)] == self.api.utility_uri:
-            _LOGGER.error(
-                f"POST from {self.address_string} contains: "
-                f"{body}     "
-                f"{resource_uri[:len(self.api.utility_uri)]}"
-                f" != {self.api.utility_uri}"
-            )
+        
+        resource_uris = []
+        for resource_uri in batch_list:
+            if not resource_uri[: len(self.api.utility_uri)] == self.api.utility_uri:
+                _LOGGER.error(
+                    f"POST from {self.address_string} contains: "
+                    f"{body}     "
+                    f"{resource_uri[:len(self.api.utility_uri)]}"
+                    f" != {self.api.utility_uri}"
+                )
+            resource_uris.append(resource_uri)
+        
+        if len(resource_uris) == 0:
+            _LOGGER.error("No resources to process")
             return
 
         self.send_response(200)
         self.end_headers()
 
-        xml_data = self.api.get_espi_data(resource_uri)
-        for _ in parse_espi_data(xml_data):
-            _LOGGER.debug("Parsed data:", _)
+        for resource_uri in resource_uris:
+            xml_data = self.api.get_espi_data(resource_uri)
+            for _ in parse_espi_data(xml_data):
+                _LOGGER.debug(f"Parsed data: {_}")
 
-        if self.save_file:
-            save_name = self.save_file(xml_data, filename=self.filename)
-            if save_name:
-                _LOGGER.info(f"XML saved at {save_name}")
-            else:
-                _LOGGER.error("File not saved.")
+            if self.save_file:
+                save_name = self.save_file(xml_data, filename=self.filename)
+                if save_name:
+                    _LOGGER.info(f"XML saved at {save_name}")
+                else:
+                    _LOGGER.error("File not saved.")
 
-        if self.to_db:
-            _LOGGER.error("Database not implemented.")
-            pass
+            if self.to_db:
+                _LOGGER.error("Database not implemented.")
+                pass
 
 
 class SelfAccessServer:

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -44,6 +44,7 @@ class PgePostHandler(BaseHTTPRequestHandler):
         
         resource_uris = []
         for resource_uri in batch_list:
+            resource_uri = resource_uri.text
             if not resource_uri[: len(self.api.utility_uri)] == self.api.utility_uri:
                 _LOGGER.error(
                     f"POST from {self.address_string} contains: "

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -67,9 +67,6 @@ class PgePostHandler(BaseHTTPRequestHandler):
 
         for resource_uri in resource_uris:
             xml_data = self.api.get_espi_data(resource_uri)
-            data = parse_espi_data(xml_data)
-            for _ in data:
-                _LOGGER.debug(f"Parsed data: {_}")
 
             if self.save_file:
                 save_name = self.save_file(xml_data, filename=self.filename)
@@ -78,9 +75,14 @@ class PgePostHandler(BaseHTTPRequestHandler):
                 else:
                     _LOGGER.error("File not saved.")
 
-            if self.to_db:
-                self.to_db(data)
-
+            try:
+                data = list(parse_espi_data(xml_data))
+                for _ in data:
+                    _LOGGER.debug(f"Parsed data: {_}")
+                if self.to_db:
+                    self.to_db(data)
+            except Exception as e:
+                _LOGGER.error(f"Failed to parse XML: {e}")
 
 class SelfAccessServer:
     """Server class for PGE SMD Self Access API."""

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -54,6 +54,8 @@ class PgePostHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
         xml_data = self.api.get_espi_data(resource_uri)
+        for _ in parse_espi_data(xml_data):
+            _LOGGER.debug("Parsed data:", _)
 
         if self.save_file:
             save_name = self.save_file(xml_data, filename=self.filename)

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -29,7 +29,7 @@ class PgePostHandler(BaseHTTPRequestHandler):
         status = self.api.get_service_status()
         self.send_response(200)
         self.end_headers()
-        self.wfile.write(str(status))
+        self.wfile.write(str(status).encode("utf-8"))
     
     def do_POST(self):
         """Download the ESPI XML and save to database."""

--- a/pgesmd_self_access/server.py
+++ b/pgesmd_self_access/server.py
@@ -103,6 +103,7 @@ class SelfAccessServer:
         filename=None,
         to_db=None,
         close_after=False,
+        use_ssl=True,
         update_path="/pgesmd",
     ):
         """Initialize and start the server on construction."""
@@ -112,6 +113,14 @@ class SelfAccessServer:
         PgePostHandler.to_db = to_db
         PgePostHandler.update_path = update_path
         server = HTTPServer(("", port), PgePostHandler)
+
+        if use_ssl:
+            server.socket = ssl.wrap_socket(
+                server.socket,
+                certfile=api_instance.cert[0],
+                keyfile=api_instance.cert[1],
+                server_side=True,
+            )
 
         if close_after:
             server.handle_request()


### PR DESCRIPTION
This PR contains a number of improvements and should maintain backwards compatibility with existing uses of this library:

- When handling a callback from PG&E, the update may contain multiple XML files (e.g. multiple utility accounts) so we gracefully handle cases for one or more files
- Addition of a `/refresh` endpoint to manually trigger callbacks
- Addition of a `/status` endpoint to act as server healthcheck
- Refactoring of default arg values for `SelfAccessServer` entry class for better flexibility